### PR TITLE
Update ios_l2_interface.py

### DIFF
--- a/lib/ansible/modules/network/ios/ios_l2_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l2_interface.py
@@ -459,10 +459,10 @@ def main():
                 module.fail_json(msg='You are trying to configure a VLAN'
                                  ' on an interface that\ndoes not exist on the '
                                  ' switch yet!', vlan=access_vlan)
-            elif native_vlan and native_vlan not in current_vlans:
-                module.fail_json(msg='You are trying to configure a VLAN'
-                                 ' on an interface that\ndoes not exist on the '
-                                 ' switch yet!', vlan=native_vlan)
+          #  elif native_vlan and native_vlan not in current_vlans:
+          #      module.fail_json(msg='You are trying to configure a VLAN'
+          #                       ' on an interface that\ndoes not exist on the '
+          #                       ' switch yet!', vlan=native_vlan)
             else:
                 command = get_switchport_config_commands(name, existing, proposed, module)
                 commands.append(command)


### PR DESCRIPTION
Native VLAN can be an unconfigured VLAN (Native VLAN does not need to be defined on the switch in current VLANs).
Fixes #43535

Try to add an unconfigured vlan manually as native vlan. Cisco IOS does not complain and it does not automatically create the VLAN.
If you do the same in the allowed_vlan_list, then Cisco IOS will complain and automatically create the VLAN (so in this case, the module can also complain)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

You should not abort the module when you try to add a native VLAN that does not exist on the switch.
By uncommenting these 4 lines, i managed to fix this.

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, task or feature -->
ios_l2_interface.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/sha
re/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, Apr 11 2018, 07:36:10) [GCC 4.8.5 20150623 (R
ed Hat 4.8.5-28)]
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->


